### PR TITLE
chore: Rename Cloudflare secret to CLOUDFLARE_API_TOKEN, standardize wrangler-action@v4

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -55,9 +55,9 @@ jobs:
 
       - name: Publish to Cloudflare Pages
         id: deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_KEY }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           wranglerVersion: "latest"
           command: >


### PR DESCRIPTION
The org secret was renamed `CLOUDFLARE_API_KEY` → `CLOUDFLARE_API_TOKEN` (rotated to a new value, aligned to the name wrangler expects). The old secret no longer exists, so this workflow would fail on its next deploy — update to the new name.

Also standardizes on `cloudflare/wrangler-action@v4` (matching stock-indicators-dotnet, which runs it fine).

No behavior change; same scoped Pages/Workers API token, correctly named, on the current action major.